### PR TITLE
Add support to run dependency resolution in parallel

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <version.maven>2.2.1</version.maven>
-    <version.jdk>1.4</version.jdk>
+    <version.jdk>1.5</version.jdk>
   </properties>
   <dependencies>
     <dependency>
@@ -95,6 +95,11 @@
         <groupId>com.pyx4j</groupId>
         <artifactId>maven-plugin-log4j</artifactId>
         <version>1.0.1</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <version>19.0</version>
     </dependency>
   </dependencies>
   <build>


### PR DESCRIPTION
Added support to run dependency resolution in parallel. Can be disabled by passing -DuseParallelDependencyResolution=false in mvn command line (true by default) or configuring in pom

Running on presto-main at presto project gives about 50% perf improvement
Without parallel dependency resolution:

```
$ mvn validate -pl presto-main -Dbuildtime.output.log=true -DuseParallelDependencyResolution=false
...
[INFO]   maven-dependency-versions-check-plugin:check (default) ... [8.988s]
...
```

Running with parallel resolution:
```
$ mvn validate -pl presto-main -Dbuildtime.output.log=true 
...
[INFO]   maven-dependency-versions-check-plugin:check (default) ... [4.408s]
...
```
