### PR TITLE
Artifact resolution from project.repositories

### DIFF
--- a/src/main/java/com/ning/maven/plugins/dependencyversionscheck/AbstractDependencyVersionsMojo.java
+++ b/src/main/java/com/ning/maven/plugins/dependencyversionscheck/AbstractDependencyVersionsMojo.java
@@ -799,7 +799,7 @@ public abstract class AbstractDependencyVersionsMojo extends AbstractMojo
             project.getArtifact(),
             Collections.EMPTY_MAP,
             localRepository,
-            remoteRepositories,
+            project.getRemoteArtifactRepositories(),
             artifactMetadataSource,
             new ArtifactOptionalFilter(includeOptional));
 


### PR DESCRIPTION
This fixes missing poms and artifacts when the repository is defined in the child pom.
