### PR TITLE
Property to enable skipping from CLI

### DIFF
--- a/src/main/java/com/ning/maven/plugins/dependencyversionscheck/AbstractDependencyVersionsMojo.java
+++ b/src/main/java/com/ning/maven/plugins/dependencyversionscheck/AbstractDependencyVersionsMojo.java
@@ -182,7 +182,7 @@ public abstract class AbstractDependencyVersionsMojo extends AbstractMojo
      *   </configuration>
      * </pre>
      *
-     * @parameter default-value="false"
+     * @parameter default-value="false" property="dependencyversionscheck.skip"
      */
     protected boolean skip = false;
 


### PR DESCRIPTION
Almost all plugins have this facility including the stock dependency plugin, cf https://github.com/apache/maven-plugins/blob/trunk/maven-dependency-plugin/src/main/java/org/apache/maven/plugins/dependency/AbstractDependencyMojo.java#L126