### PR TITLE
Avoid HashMap concurrent access issue in dependency-version-check-work executor service

### DIFF
--- a/src/main/java/com/ning/maven/plugins/dependencyversionscheck/AbstractDependencyVersionsMojo.java
+++ b/src/main/java/com/ning/maven/plugins/dependencyversionscheck/AbstractDependencyVersionsMojo.java
@@ -26,6 +26,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.SortedMap;
 import java.util.TreeMap;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
 import java.util.concurrent.locks.Lock;
@@ -257,13 +258,13 @@ public abstract class AbstractDependencyVersionsMojo extends AbstractMojo
     protected final Logger LOG = LoggerFactory.getLogger(this.getClass());
 
     /** ArtifactName to VersionStrategy. Filled in loadResolvers(). */
-    protected final Map resolverMap = new HashMap();
+    protected final Map resolverMap = new ConcurrentHashMap();
 
     /** Artifact pattern to VersionStrategy. Filled in loadResolvers(). */
-    protected final Map resolverPatternMap = new HashMap();
+    protected final Map resolverPatternMap = new ConcurrentHashMap();
 
     /** Qualified artifact name to artifact. */
-    protected final Map resolvedDependenciesByName = new HashMap();
+    protected final Map resolvedDependenciesByName = new ConcurrentHashMap();
 
     protected Strategy defaultStrategyType;
 


### PR DESCRIPTION

Details:
resolverMap is used in an executor service without synchronization. In very rare cases, this plugin reports below concurrent error -

Caused by: java.lang.ClassCastException: java.util.HashMap cannot be cast to java.util.HashMap
at java.util.HashMap.moveRootToFront (HashMap.java:1832)
at java.util.HashMap.treeify (HashMap.java:1949)
at java.util.HashMap.treeifyBin (HashMap.java:772)
at java.util.HashMap.putVal (HashMap.java:644)
at java.util.HashMap.put (HashMap.java:612)
at com.ning.maven.plugins.dependencyversionscheck.AbstractDependencyVersionsMojo.findStrategy (AbstractDependencyVersionsMojo.java:423)
at com.ning.maven.plugins.dependencyversionscheck.AbstractDependencyVersionsMojo.resolveVersion (AbstractDependencyVersionsMojo.java:627)
at com.ning.maven.plugins.dependencyversionscheck.AbstractDependencyVersionsMojo.updateResolutionMapForDep (AbstractDependencyVersionsMojo.java:511)
at com.ning.maven.plugins.dependencyversionscheck.AbstractDependencyVersionsMojo.access-bash00 (AbstractDependencyVersionsMojo.java:88)
at com.ning.maven.plugins.dependencyversionscheck.AbstractDependencyVersionsMojo.run (AbstractDependencyVersionsMojo.java:458)
at java.util.concurrent.Executors.call (Executors.java:511)
at com.google.common.util.concurrent.TrustedListenableFutureTask.runInterruptibly (TrustedListenableFutureTask.java:108)
at com.google.common.util.concurrent.InterruptibleTask.run (InterruptibleTask.java:41)
at com.google.common.util.concurrent.TrustedListenableFutureTask.run (TrustedListenableFutureTask.java:77)
at java.util.concurrent.ThreadPoolExecutor.runWorker (ThreadPoolExecutor.java:1149)
at java.util.concurrent.ThreadPoolExecutor.run (ThreadPoolExecutor.java:624)
at java.lang.Thread.run (Thread.java:748)

Also change resolverPatternMap and resolvedDependenciesByName to ConcurrentHashMap for consistency.